### PR TITLE
Fix opBinaryRight error message to suggest lhs instead of rhs

### DIFF
--- a/compiler/src/dmd/opover.d
+++ b/compiler/src/dmd/opover.d
@@ -612,7 +612,7 @@ bool suggestBinaryOverloads(BinExp e, Scope* sc)
             return true;
         }
         error(e.loc, "operator `%s` is not defined for type `%s`", EXPtoString(e.op).ptr, e.e2.type.toChars);
-        errorSupplemental(ad2.loc, "perhaps overload the operator with `auto opBinaryRight(string op : \"%s\")(%s rhs) {}`", EXPtoString(e.op).ptr, e.e1.type.toChars);
+        errorSupplemental(ad2.loc, "perhaps overload the operator with `auto opBinaryRight(string op : \"%s\")(%s lhs) {}`", EXPtoString(e.op).ptr, e.e1.type.toChars);
         return true;
     }
     return false;

--- a/compiler/test/fail_compilation/dep_d1_ops.d
+++ b/compiler/test/fail_compilation/dep_d1_ops.d
@@ -5,23 +5,23 @@ TEST_OUTPUT:
 fail_compilation/dep_d1_ops.d(281): Error: operator `+` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : "+")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(282): Error: operator `+` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "+")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "+")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(283): Error: operator `-` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : "-")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(284): Error: operator `-` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "-")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "-")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(285): Error: operator `*` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : "*")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(286): Error: operator `*` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "*")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "*")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(287): Error: operator `/` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : "/")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(288): Error: operator `/` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "/")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "/")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(289): Error: operator `%` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : "%")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(290): Error: operator `%` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "%")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "%")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(292): Error: operator `&` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : "&")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(293): Error: operator `|` is not defined for type `S`
@@ -31,19 +31,19 @@ fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `a
 fail_compilation/dep_d1_ops.d(296): Error: operator `<<` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : "<<")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(297): Error: operator `<<` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "<<")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "<<")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(298): Error: operator `>>` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : ">>")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(299): Error: operator `>>` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : ">>")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : ">>")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(300): Error: operator `>>>` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : ">>>")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(301): Error: operator `>>>` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : ">>>")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : ">>>")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(303): Error: operator `~` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : "~")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(304): Error: operator `~` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "~")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "~")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(306): Error: operator `+` is not defined for `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opUnary(string op : "+")() {}`
 fail_compilation/dep_d1_ops.d(307): Error: operator `-` is not defined for `S`
@@ -59,7 +59,7 @@ fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `a
 fail_compilation/dep_d1_ops.d(313): Error: operator `in` is not defined for type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinary(string op : "in")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(314): Error: operator `in` is not defined for type `S`
-fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "in")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(174):        perhaps overload the operator with `auto opBinaryRight(string op : "in")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(316): Error: operator `+=` not supported for `s` of type `S`
 fail_compilation/dep_d1_ops.d(174):        perhaps implement `auto opOpAssign(string op : "+")(int) {}`
 fail_compilation/dep_d1_ops.d(317): Error: operator `-=` not supported for `s` of type `S`
@@ -87,23 +87,23 @@ fail_compilation/dep_d1_ops.d(174):        perhaps implement `auto opOpAssign(st
 fail_compilation/dep_d1_ops.d(331): Error: operator `+` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : "+")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(332): Error: operator `+` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "+")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "+")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(333): Error: operator `-` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : "-")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(334): Error: operator `-` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "-")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "-")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(335): Error: operator `*` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : "*")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(336): Error: operator `*` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "*")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "*")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(337): Error: operator `/` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : "/")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(338): Error: operator `/` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "/")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "/")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(339): Error: operator `%` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : "%")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(340): Error: operator `%` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "%")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "%")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(342): Error: operator `&` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : "&")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(343): Error: operator `|` is not defined for type `dep_d1_ops.C`
@@ -113,19 +113,19 @@ fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `a
 fail_compilation/dep_d1_ops.d(346): Error: operator `<<` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : "<<")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(347): Error: operator `<<` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "<<")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "<<")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(348): Error: operator `>>` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : ">>")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(349): Error: operator `>>` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : ">>")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : ">>")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(350): Error: operator `>>>` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : ">>>")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(351): Error: operator `>>>` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : ">>>")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : ">>>")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(353): Error: operator `~` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : "~")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(354): Error: operator `~` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "~")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "~")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(356): Error: operator `+` is not defined for `C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opUnary(string op : "+")() {}`
 fail_compilation/dep_d1_ops.d(357): Error: operator `-` is not defined for `C`
@@ -141,7 +141,7 @@ fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `a
 fail_compilation/dep_d1_ops.d(363): Error: operator `in` is not defined for type `dep_d1_ops.C`
 fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinary(string op : "in")(int rhs) {}`
 fail_compilation/dep_d1_ops.d(364): Error: operator `in` is not defined for type `dep_d1_ops.C`
-fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "in")(int rhs) {}`
+fail_compilation/dep_d1_ops.d(225):        perhaps overload the operator with `auto opBinaryRight(string op : "in")(int lhs) {}`
 fail_compilation/dep_d1_ops.d(366): Error: operator `+=` not supported for `c` of type `C`
 fail_compilation/dep_d1_ops.d(225):        perhaps implement `auto opOpAssign(string op : "+")(int) {}`
 fail_compilation/dep_d1_ops.d(367): Error: operator `-=` not supported for `c` of type `C`

--- a/compiler/test/fail_compilation/diag16499.d
+++ b/compiler/test/fail_compilation/diag16499.d
@@ -2,9 +2,9 @@
 TEST_OUTPUT:
 ---
 fail_compilation/diag16499.d(24): Error: operator `in` is not defined for type `A`
-fail_compilation/diag16499.d(11):        perhaps overload the operator with `auto opBinaryRight(string op : "in")(int rhs) {}`
+fail_compilation/diag16499.d(11):        perhaps overload the operator with `auto opBinaryRight(string op : "in")(int lhs) {}`
 fail_compilation/diag16499.d(26): Error: operator `in` is not defined for type `B`
-fail_compilation/diag16499.d(12):        perhaps overload the operator with `auto opBinaryRight(string op : "in")(double rhs) {}`
+fail_compilation/diag16499.d(12):        perhaps overload the operator with `auto opBinaryRight(string op : "in")(double lhs) {}`
 ---
 */
 

--- a/compiler/test/fail_compilation/issue22147.d
+++ b/compiler/test/fail_compilation/issue22147.d
@@ -1,0 +1,16 @@
+/*
+TEST_OUTPUT:
+---
+fail_compilation/issue22147.d(15): Error: operator `/` is not defined for type `T`
+fail_compilation/issue22147.d(9):        perhaps overload the operator with `auto opBinaryRight(string op : "/")(int lhs) {}`
+---
+*/
+
+struct T
+{
+}
+
+void main()
+{
+    auto result = 10 / T();  // int / T requires opBinaryRight on T
+}


### PR DESCRIPTION
Close #22147 
For `opBinaryRight`, the parameter represents the left-hand side operand, so it should be `lhs`